### PR TITLE
Update plugin to use oEmbed while maintaining backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Ustream for WordPress is a plugin that enables the user to embed Ustream live and recorded embeds. Put the url for the ustream video you'd like between the embed tags.
+# Ustream for WordPress
+
+A Wordpress plugin that enables the user to embed Ustream live and recorded embeds. Put the url for the ustream video you'd like between the embed tags.
 
     [embed]http://www.ustream.tv/recorded/98889950[/embed]
     [embed]http://www.ustream.tv/channel/iss-hdev-payload[/embed]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
-Ustream for WordPress is a plugin that enables the user to add tags (short codes) on the format [ustream cid="xxxxx"] or [ustream vid="xxxxx"] in blog posts/pages and have them replaced by their video content from UStream.
+Ustream for WordPress is a plugin that enables the user to embed Ustream live and recorded embeds. Put the url for the ustream video you'd like between the embed tags.
+
+    [embed]http://www.ustream.tv/recorded/98889950[/embed]
+    [embed]http://www.ustream.tv/channel/iss-hdev-payload[/embed]
 
 This really comes in handy when your blog is on a multi site WordPress instance where you are not allowed to add iframe code etc.
 
-This plugin uses short codes and automatically replaces the [ustream cid="xxxxx"] or [ustream vid="xxxxx"] tags with the embeded video related to the given cid or vid.
+### Deprecated shortcode embed method
 
-The [ustream cid="xxxxx"] tag is used when you want to stream a live broad cast and the [ustream vid="xxxxx"] is used when to publish a recorded video.
+The deprecated method for embedding Ustream still works, but ignores all non-oEmbed info. One can add tags (short codes) on the format `[ustream cid="xxxxx"]` or `[ustream vid="xxxxx"]` in blog posts/pages and have them replaced by their video content from UStream.
+
+This deprecated method uses short codes and automatically replaces the `[ustream cid="xxxxx"]` or `[ustream vid="xxxxx"]` tags with the embedded video related to the given cid or vid.
+
+The `[ustream cid="xxxxx"]` tag is used when you want to stream a live broad cast and the `[ustream vid="xxxxx"]` is used when to publish a recorded video.

--- a/readme.txt
+++ b/readme.txt
@@ -1,19 +1,26 @@
 === Plugin Name ===
 
-Contributors: hoyce
+Contributors: hoyce, signalfade
 Donate link: http://ustream.tv/
 Tags: embed, oembed, video, ustream, player, viewer, broadcast, live
 Requires at least: 3.0
-Tested up to: 3.9
-Stable tag: 1.1.0
+Tested up to: 4.7.1
+Stable tag: 2.1.0
 
 == Description ==
 
-Ustream for WordPress is a plugin that enables the user to add tags (short codes) on the format [ustream cid="xxxxx"] or [ustream vid="xxxxx"] in blog posts/pages and have them replaced by their video content from UStream.
+Ustream for WordPress is a plugin that enables the user to embed Ustream live and recorded embeds. Put the url for the ustream video you'd like between the embed tags.
+
+    [embed]http://www.ustream.tv/recorded/98889950[/embed]
+    [embed]http://www.ustream.tv/channel/iss-hdev-payload[/embed]
 
 This really comes in handy when your blog is on a multi site WordPress instance where you are not allowed to add iframe code etc.
 
-This plugin uses short codes and automatically replaces the [ustream cid="xxxxx"] or [ustream vid="xxxxx"] tags with the embeded video related to the given cid or vid.
+### Deprecated shortcode embed method
+
+The deprecated method for embedding Ustream still works, but ignores all non-oembed info. One can add tags (short codes) on the format `[ustream cid="xxxxx"]` or `[ustream vid="xxxxx"]` in blog posts/pages and have them replaced by their video content from UStream.
+
+This deprecated method uses short codes and automatically replaces the [ustream cid="xxxxx"] or [ustream vid="xxxxx"] tags with the embedded video related to the given cid or vid.
 
 The [ustream cid="xxxxx"] tag is used when you want to stream a live broad cast and the [ustream vid="xxxxx"] is used when to publish a recorded video.
 
@@ -33,7 +40,7 @@ Manually
 1. Upload `ustream-for-wordpress` folder to the `/wp-content/plugins/` directory
 2. Activate the plugin through the 'Plugins' menu in WordPress
 
-You should now be able to paste use the [ustream cid="xxxxxxx"] tag in blog posts/pages and have them replaced by their video content from UStream.
+You should now be able to paste use the plugin using the `[embed][/embed]` tags.
 
 == Changelog ==
 
@@ -47,3 +54,11 @@ You should now be able to paste use the [ustream cid="xxxxxxx"] tag in blog post
 = 1.1.0 =
 * Added this plugin to Github https://github.com/hoyce/ustream-for-wordpress
 * Tested stability up to Wordpress 3.9
+
+= 2.0 =
+* Changed embed code due to new code from UStream
+* Tested in WordPress 4.0
+
+= 2.1 =
+* Changed embed code use oEmbed specification and service
+* Tested in WordPress 4.7.1

--- a/utream-for-wordpress.php
+++ b/utream-for-wordpress.php
@@ -3,7 +3,7 @@
  Plugin Name: UStream for WordPress
  Plugin URI: http://www.geckosolutions.se/blog/wordpress-plugins/
  Description: Add easy to use functionality to embed UStrem videos and broadcasts.
- Version: 1.1.0
+ Version: 1.1.1
  Author: Niklas Olsson
  Author URI: http://www.geckosolutions.se
  License: GPL 2.0, @see http://www.gnu.org/licenses/gpl-2.0.html
@@ -11,30 +11,24 @@
 
 class ustream_for_wordpress {
     
+	function oembed_provider() {
+	    wp_oembed_add_provider( '#http://(www\.)?ustream.tv/*#i', 'http://www.ustream.tv/oembed', true );
+	}
+
+	// Maintain backward compatibility of this plugin
 	function get_ustream_code($atts, $content=null) {
-	    
-    	extract(shortcode_atts(array('cid' => '', 'vid' => '', 'width' => '480', 'height' => '296'), $atts));
+	    extract(shortcode_atts(array('cid' => '', 'vid' => ''), $atts));
 
 	    if (is_numeric($cid)) {
-	      return '<object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="'.$width.'" height="'.$height.'">
-									<param name="flashvars" value="autoplay=false&amp;brand=embed&amp;cid='.$cid.'&amp;v3=1"/>
-									<param name="allowfullscreen" value="true"/>
-									<param name="allowscriptaccess" value="always"/>
-									<param name="movie" value="http://www.ustream.tv/flash/viewer.swf"/>
-									<embed flashvars="autoplay=false&amp;brand=embed&amp;cid='.$cid.'&amp;v3=1" width="'.$width.'" height="'.$height.'" allowfullscreen="true" allowscriptaccess="always" src="http://www.ustream.tv/flash/viewer.swf" type="application/x-shockwave-flash" /></object>';
+		return wp_oembed_get('http://www.ustream.tv/'.$cid);
 	    } else if (is_numeric($vid)) {
-	      return '<object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="'.$width.'" height="296">
-	      					<param name="flashvars" value="loc=%2F&amp;autoplay=false&amp;vid='.$vid.'&amp;locale=en_US&amp;hasticket=false&amp;id='.$vid.'&amp;v3=1" />
-	      					<param name="allowfullscreen" value="true" />
-	      					<param name="allowscriptaccess" value="always" />
-	      					<param name="src" value="http://www.ustream.tv/flash/viewer.swf" />
-	      					<embed flashvars="loc=%2F&amp;autoplay=false&amp;vid='.$vid.'&amp;locale=en_US&amp;hasticket=false&amp;id='.$vid.'&amp;v3=1" width="'.$width.'" height="'.$height.'" allowfullscreen="true" allowscriptaccess="always" src="http://www.ustream.tv/flash/viewer.swf" type="application/x-shockwave-flash" />
-	      			  </object>';
+		return wp_oembed_get('http://www.ustream.tv/'.$vid);
 	    } else {
-	      return 'Error: Nore the "cid" or the "vid" is given to the ustream tag!';
+	      return 'Error: Neither the "cid" nor the "vid" was passed to the ustream tag!';
 	    }
     }
 }
 
+add_action( 'init', array('ustream_for_wordpress', 'oembed_provider') );
+// Maintain backward compatibility of this plugin
 add_shortcode('ustream', array('ustream_for_wordpress', 'get_ustream_code'));
-?>

--- a/utream-for-wordpress.php
+++ b/utream-for-wordpress.php
@@ -3,29 +3,29 @@
  Plugin Name: UStream for WordPress
  Plugin URI: http://www.geckosolutions.se/blog/wordpress-plugins/
  Description: Add easy to use functionality to embed UStrem videos and broadcasts.
- Version: 1.1.1
+ Version: 2.1
  Author: Niklas Olsson
  Author URI: http://www.geckosolutions.se
  License: GPL 2.0, @see http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 class ustream_for_wordpress {
-    
-	function oembed_provider() {
-	    wp_oembed_add_provider( '#http://(www\.)?ustream.tv/*#i', 'http://www.ustream.tv/oembed', true );
-	}
 
-	// Maintain backward compatibility of this plugin
-	function get_ustream_code($atts, $content=null) {
-	    extract(shortcode_atts(array('cid' => '', 'vid' => ''), $atts));
+    function oembed_provider() {
+        wp_oembed_add_provider( '#http://(www\.)?ustream.tv/*#i', 'http://www.ustream.tv/oembed', true );
+    }
 
-	    if (is_numeric($cid)) {
-		return wp_oembed_get('http://www.ustream.tv/'.$cid);
-	    } else if (is_numeric($vid)) {
-		return wp_oembed_get('http://www.ustream.tv/'.$vid);
-	    } else {
-	      return 'Error: Neither the "cid" nor the "vid" was passed to the ustream tag!';
-	    }
+    // Maintain backward compatibility of this plugin
+    function get_ustream_code($atts, $content=null) {
+        extract(shortcode_atts(array('cid' => '', 'vid' => ''), $atts));
+
+        if (is_numeric($cid)) {
+            return wp_oembed_get('http://www.ustream.tv/channel/'.$cid);
+        } else if (is_numeric($vid)) {
+            return wp_oembed_get('http://www.ustream.tv/recorded/'.$vid);
+        } else {
+          return 'Error: Neither the "cid" nor the "vid" was passed to the ustream tag!';
+        }
     }
 }
 


### PR DESCRIPTION
Update plugin to use oEmbed while maintaining backwards compatibility to the [ustream] shortcodes.